### PR TITLE
Remove -flto flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,7 @@
         '-Wall',
         '-march=native',
         '-Ofast',
+        '-flto',
         '-funroll-loops'
     ],
     'xcode_settings': {


### PR DESCRIPTION
With LTO enabled, the linker fails on my machine with the error `LLVM ERROR: Cannot select: intrinsic %llvm.x86.aesni.aesimc`. I have Xcode 6.1 on OS X 10.9.5 on a Macbook Air with a Core i7.

```
$ c++ -v
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix
```
