### PR TITLE
Support node Buffers as well as JS Strings for 32 bit hashes

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -120,47 +120,63 @@ var randomStringOfLength = function(length) {
   console.log('Test key length performance');
 
   var seed = randomInteger();
+  var seed2 = randomInteger();
   console.log('Using seed ' + seed);
 
-  [100, 1000, 10000].forEach(function(length) {
+    [100, 1000, 10000].forEach(function(length) {
 
     var input = randomStringOfLength(length);
     var inputBuffer = new Buffer(input); // xxhash
     console.log('Using key of length ' + length);
 
     (new Benchmark.Suite())
-    .add('murmurhash3', function() {
-      murmurhash3.murmur32Sync(input);
-    })
-    .add('murmurhash3+seed', function() {
-      murmurhash3.murmur32Sync(input, seed);
-    })
-    .add('farmhash-hash-switch-string', function() {
+    // .add('murmurhash3', function() {
+    //   murmurhash3.murmur32Sync(input);
+    // })
+    // .add('murmurhash3+seed', function() {
+    //   murmurhash3.murmur32Sync(input, seed);
+    // })
+    .add('farmhash-hash32-string', function() {
       farmhash.hash32(input);
     })
-    .add('farmhash-hash-switch-buffer', function() {
+    .add('farmhash-hash32-buffer', function() {
       farmhash.hash32(inputBuffer);
     })
-    .add('farmhash-hash-buffer-only', function() {
-      farmhash.hash32Buffer(inputBuffer);
-    })
-    .add('farmhash-hash-string-only', function() {
-      farmhash.hash32String(input);
-    })
-    .add('farmhash-hash+seed-switch-string', function() {
+    .add('farmhash-hash32+seed-string', function() {
       farmhash.hash32WithSeed(input, seed);
     })
-    .add('farmhash-hash+seed-switch-buffer', function() {
+    .add('farmhash-hash32+seed-buffer', function() {
       farmhash.hash32WithSeed(inputBuffer, seed);
     })
-    .add('farmhash-hash+seed-string-only', function() {
-      farmhash.hash32WithSeedString(input, seed);
-    })
-    .add('farmhash-hash+seed-buffer-only', function() {
-      farmhash.hash32WithSeedBuffer(inputBuffer, seed);
-    })
-    .add('farmhash-fingerprint', function() {
+    .add('farmhash-fingerprint32-string', function() {
       farmhash.fingerprint32(input);
+    })
+    .add('farmhash-fingerprint32-buffer', function() {
+      farmhash.fingerprint32(inputBuffer);
+    })
+    .add('farmhash-fingerprint64-string', function() {
+      farmhash.fingerprint64(input);
+    })
+    .add('farmhash-fingerprint64-buffer', function() {
+      farmhash.fingerprint64(inputBuffer);
+    })
+    .add('farmhash-hash64-string', function() {
+      farmhash.hash64(input);
+    })
+    .add('farmhash-hash64-buffer', function() {
+      farmhash.hash64(inputBuffer);
+    })
+    .add('farmhash-hash64+seed-string', function() {
+      farmhash.hash64WithSeed(input, seed);
+    })
+    .add('farmhash-hash64+seed-buffer', function() {
+      farmhash.hash64WithSeed(inputBuffer, seed);
+    })
+    .add('farmhash-hash64+seeds-string', function() {
+      farmhash.hash64WithSeeds(input, seed, seed2);
+    })
+    .add('farmhash-hash64+seeds-buffer', function() {
+      farmhash.hash64WithSeeds(inputBuffer, seed, seed2);
     })
     .add('xxhash+seed', function() {
       xxhash.hash(inputBuffer, seed);

--- a/index.js
+++ b/index.js
@@ -30,56 +30,72 @@ module.exports = {
 
   // Hash methods - platform dependent
   hash32: function(input) {
-    verifyStringOrBuffer(input);
-    return farmhash.Hash32(input);
-  },
-  hash32Buffer: function(input) {
-    verifyBuffer(input);
-    return farmhash.Hash32Buffer(input);
-  },
-  hash32String: function(input) {
-    verifyString(input);
-    return farmhash.Hash32String(input);
+    if (typeof input === 'string') {
+      return farmhash.Hash32String(input);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Hash32Buffer(input);
+    }
+    throw new Error('Expected a String or Buffer for input');
   },
   hash32WithSeed: function(input, seed) {
-    verifyStringOrBuffer(input);
     verifyInteger(seed);
-    return farmhash.Hash32WithSeed(input, seed);
-  },
-  hash32WithSeedString: function(input, seed) {
-    verifyString(input);
-    verifyInteger(seed);
-    return farmhash.Hash32WithSeedString(input, seed);
-  },
-  hash32WithSeedBuffer: function(input, seed) {
-    verifyBuffer(input);
-    verifyInteger(seed);
-    return farmhash.Hash32WithSeedBuffer(input, seed);
+    if (typeof input === 'string') {
+      return farmhash.Hash32WithSeedString(input, seed);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Hash32WithSeedBuffer(input, seed);
+    }
+    throw new Error('Expected a String or Buffer for input');
   },
   hash64: function(input) {
-    verifyString(input);
+    if (typeof input === 'string') {
+      return farmhash.Hash64String(input);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Hash64Buffer(input);
+    }
+    throw new Error('Expected a String or Buffer for input');
     return farmhash.Hash64(input);
   },
   hash64WithSeed: function(input, seed) {
-    verifyString(input);
     verifyInteger(seed);
-    return farmhash.Hash64WithSeed(input, seed);
+    if (typeof input === 'string') {
+      return farmhash.Hash64WithSeedString(input, seed);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Hash64WithSeedBuffer(input, seed);
+    }
+    throw new Error('Expected a String or Buffer for input');
   },
   hash64WithSeeds: function(input, seed1, seed2) {
-    verifyString(input);
     verifyInteger(seed1);
     verifyInteger(seed2);
-    return farmhash.Hash64WithSeeds(input, seed1, seed2);
+    if (typeof input === 'string') {
+      return farmhash.Hash64WithSeedsString(input, seed1, seed2);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Hash64WithSeedsBuffer(input, seed1, seed2);
+    }
+    throw new Error('Expected a String or Buffer for input');
   },
 
   // Fingerprint methods - platform independent
   fingerprint32: function(input) {
-    verifyString(input);
-    return farmhash.Fingerprint32(input);
+    if (typeof input === 'string') {
+      return farmhash.Fingerprint32String(input);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Fingerprint32Buffer(input);
+    }
+    throw new Error('Expected a String or Buffer for input');
   },
   fingerprint64: function(input) {
-    verifyString(input);
-    return farmhash.Fingerprint64(input);
+    if (typeof input === 'string') {
+      return farmhash.Fingerprint64String(input);
+    }
+    if (Buffer.isBuffer(input)) {
+      return farmhash.Fingerprint64Buffer(input);
+    }
   }
-
 };

--- a/src/farmhash.cc
+++ b/src/farmhash.cc
@@ -19,22 +19,6 @@ string Uint64ToString(const T& t) {
 
 // Hash methods - platform dependent
 
-NAN_METHOD(Hash32) {
-  NanScope();
-
-  string input;
-
-  if (Buffer::HasInstance(args[0])) {
-    Local<Object> buffer_obj = args[0]->ToObject();
-    input = string(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj));
-  } else {
-    input = *String::Utf8Value(args[0]->ToString());
-  }
-
-  uint32_t hash = Hash32(input);
-  NanReturnValue(NanNew<Uint32>(hash));
-}
-
 NAN_METHOD(Hash32Buffer) {
   NanScope();
   Local<Object> buffer_obj = args[0]->ToObject();
@@ -49,20 +33,11 @@ NAN_METHOD(Hash32String) {
   NanReturnValue(NanNew<Uint32>(hash));
 }
 
-NAN_METHOD(Hash32WithSeed) {
+NAN_METHOD(Hash32WithSeedBuffer) {
   NanScope();
-
-  string input;
-
-  if (Buffer::HasInstance(args[0])) {
-    Local<Object> buffer_obj = args[0]->ToObject();
-    input = string(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj));
-  } else {
-    input = *String::Utf8Value(args[0]->ToString());
-  }
-
+  Local<Object> buffer_obj = args[0]->ToObject();
   uint32_t seed = args[1]->Uint32Value();
-  uint32_t hash = Hash32WithSeed(input, seed);
+  uint32_t hash = Hash32WithSeed(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj), seed);
   NanReturnValue(NanNew<Uint32>(hash));
 }
 
@@ -74,22 +49,29 @@ NAN_METHOD(Hash32WithSeedString) {
   NanReturnValue(NanNew<Uint32>(hash));
 }
 
-NAN_METHOD(Hash32WithSeedBuffer) {
+NAN_METHOD(Hash64Buffer) {
   NanScope();
   Local<Object> buffer_obj = args[0]->ToObject();
-  uint32_t seed = args[1]->Uint32Value();
-  uint32_t hash = Hash32WithSeed(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj), seed);
-  NanReturnValue(NanNew<Uint32>(hash));
+  uint64_t hash = Hash64(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj));
+  NanReturnValue(NanNew<String>(Uint64ToString(hash)));
 }
 
-NAN_METHOD(Hash64) {
+NAN_METHOD(Hash64String) {
   NanScope();
   string input = *String::Utf8Value(args[0]->ToString());
   uint64_t hash = Hash64(input);
   NanReturnValue(NanNew<String>(Uint64ToString(hash)));
 }
 
-NAN_METHOD(Hash64WithSeed) {
+NAN_METHOD(Hash64WithSeedBuffer) {
+  NanScope();
+  Local<Object> buffer_obj = args[0]->ToObject();
+  uint64_t seed = args[1]->IntegerValue();
+  uint64_t hash = Hash64WithSeed(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj), seed);
+  NanReturnValue(NanNew<String>(Uint64ToString(hash)));
+}
+
+NAN_METHOD(Hash64WithSeedString) {
   NanScope();
   string input = *String::Utf8Value(args[0]->ToString());
   uint64_t seed = args[1]->IntegerValue();
@@ -97,7 +79,16 @@ NAN_METHOD(Hash64WithSeed) {
   NanReturnValue(NanNew<String>(Uint64ToString(hash)));
 }
 
-NAN_METHOD(Hash64WithSeeds) {
+NAN_METHOD(Hash64WithSeedsBuffer) {
+  NanScope();
+  Local<Object> buffer_obj = args[0]->ToObject();
+  uint64_t seed1 = args[1]->IntegerValue();
+  uint64_t seed2 = args[2]->IntegerValue();
+  uint64_t hash = Hash64WithSeeds(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj), seed1, seed2);
+  NanReturnValue(NanNew<String>(Uint64ToString(hash)));
+}
+
+NAN_METHOD(Hash64WithSeedsString) {
   NanScope();
   string input = *String::Utf8Value(args[0]->ToString());
   uint64_t seed1 = args[1]->IntegerValue();
@@ -108,14 +99,28 @@ NAN_METHOD(Hash64WithSeeds) {
 
 // Fingerprint methods - platform independent
 
-NAN_METHOD(Fingerprint32) {
+NAN_METHOD(Fingerprint32Buffer) {
+  NanScope();
+  Local<Object> buffer_obj = args[0]->ToObject();
+  uint32_t hash = Fingerprint32(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj));
+  NanReturnValue(NanNew<Uint32>(hash));
+}
+
+NAN_METHOD(Fingerprint32String) {
   NanScope();
   string input = *String::Utf8Value(args[0]->ToString());
   uint32_t hash = Fingerprint32(input);
   NanReturnValue(NanNew<Uint32>(hash));
 }
 
-NAN_METHOD(Fingerprint64) {
+NAN_METHOD(Fingerprint64Buffer) {
+  NanScope();
+  Local<Object> buffer_obj = args[0]->ToObject();
+  uint64_t hash = Fingerprint64(Buffer::Data(buffer_obj), Buffer::Length(buffer_obj));
+  NanReturnValue(NanNew<String>(Uint64ToString(hash)));
+}
+
+NAN_METHOD(Fingerprint64String) {
   NanScope();
   string input = *String::Utf8Value(args[0]->ToString());
   uint64_t hash = Fingerprint64(input);
@@ -126,17 +131,20 @@ NAN_METHOD(Fingerprint64) {
 
 extern "C" void init(Handle<Object> target) {
   NanScope();
-  NODE_SET_METHOD(target, "Hash32", Hash32);
   NODE_SET_METHOD(target, "Hash32Buffer", Hash32Buffer);
   NODE_SET_METHOD(target, "Hash32String", Hash32String);
-  NODE_SET_METHOD(target, "Hash32WithSeed", Hash32WithSeed);
-  NODE_SET_METHOD(target, "Hash32WithSeedString", Hash32WithSeedString);
   NODE_SET_METHOD(target, "Hash32WithSeedBuffer", Hash32WithSeedBuffer);
-  NODE_SET_METHOD(target, "Hash64", Hash64);
-  NODE_SET_METHOD(target, "Hash64WithSeed", Hash64);
-  NODE_SET_METHOD(target, "Hash64WithSeeds", Hash64);
-  NODE_SET_METHOD(target, "Fingerprint32", Fingerprint32);
-  NODE_SET_METHOD(target, "Fingerprint64", Fingerprint64);
+  NODE_SET_METHOD(target, "Hash32WithSeedString", Hash32WithSeedString);
+  NODE_SET_METHOD(target, "Hash64Buffer", Hash64Buffer);
+  NODE_SET_METHOD(target, "Hash64String", Hash64String);
+  NODE_SET_METHOD(target, "Hash64WithSeedBuffer", Hash64WithSeedBuffer);
+  NODE_SET_METHOD(target, "Hash64WithSeedString", Hash64WithSeedString);
+  NODE_SET_METHOD(target, "Hash64WithSeedsBuffer", Hash64WithSeedsBuffer);
+  NODE_SET_METHOD(target, "Hash64WithSeedsString", Hash64WithSeedsString);
+  NODE_SET_METHOD(target, "Fingerprint32Buffer", Fingerprint32Buffer);
+  NODE_SET_METHOD(target, "Fingerprint32String", Fingerprint32String);
+  NODE_SET_METHOD(target, "Fingerprint64Buffer", Fingerprint64Buffer);
+  NODE_SET_METHOD(target, "Fingerprint64String", Fingerprint64String);
 }
 
 NODE_MODULE(farmhash, init)


### PR DESCRIPTION
For our application, we'd like to use node Buffers, but the current implementation only supports Strings. This is a change to explore different methods of supporting Buffers and the associated performance.

Is there a better way to support Buffers?
## Performance

The Buffer methods perform significantly better than the String methods. I wasn't able to figure out exactly why. Either way, 10M ops/sec is pretty nice.
### MacBook Pro

I found that the Buffer tests ran significantly faster with the AC power connected, whereas the others weren't changed much.

```
Test key length performance
Using seed 865743556
Using key of length 100
murmurhash3 x 3,874,832 ops/sec ±0.53% (98 runs sampled)
murmurhash3+seed x 2,511,932 ops/sec ±0.47% (98 runs sampled)
farmhash-hash-switch-string x 2,904,867 ops/sec ±0.96% (91 runs sampled)
farmhash-hash-switch-buffer x 4,429,890 ops/sec ±0.51% (97 runs sampled)
farmhash-hash-buffer-only x 10,271,055 ops/sec ±0.59% (97 runs sampled)
farmhash-hash-string-only x 3,030,743 ops/sec ±0.94% (98 runs sampled)
farmhash-hash+seed-switch-string x 2,856,352 ops/sec ±0.84% (91 runs sampled)
farmhash-hash+seed-switch-buffer x 4,193,309 ops/sec ±0.94% (94 runs sampled)
farmhash-hash+seed-string-only x 2,948,481 ops/sec ±0.81% (96 runs sampled)
farmhash-hash+seed-buffer-only x 9,350,736 ops/sec ±0.57% (99 runs sampled)
farmhash-fingerprint x 2,179,328 ops/sec ±0.82% (99 runs sampled)
xxhash+seed x 8,007,385 ops/sec ±0.48% (97 runs sampled)
Using key of length 1000
murmurhash3 x 1,482,526 ops/sec ±0.42% (101 runs sampled)
murmurhash3+seed x 1,496,896 ops/sec ±0.39% (97 runs sampled)
farmhash-hash-switch-string x 1,663,623 ops/sec ±0.46% (101 runs sampled)
farmhash-hash-switch-buffer x 2,286,227 ops/sec ±0.40% (102 runs sampled)
farmhash-hash-buffer-only x 3,432,985 ops/sec ±0.56% (100 runs sampled)
farmhash-hash-string-only x 1,703,900 ops/sec ±0.57% (101 runs sampled)
farmhash-hash+seed-switch-string x 2,101,446 ops/sec ±0.49% (97 runs sampled)
farmhash-hash+seed-switch-buffer x 3,060,516 ops/sec ±0.42% (98 runs sampled)
farmhash-hash+seed-string-only x 2,160,667 ops/sec ±0.55% (100 runs sampled)
farmhash-hash+seed-buffer-only x 5,337,616 ops/sec ±0.49% (99 runs sampled)
farmhash-fingerprint x 1,650,335 ops/sec ±0.37% (99 runs sampled)
xxhash+seed x 3,462,425 ops/sec ±0.42% (99 runs sampled)
Using key of length 10000
murmurhash3 x 245,128 ops/sec ±0.37% (98 runs sampled)
murmurhash3+seed x 244,759 ops/sec ±0.47% (101 runs sampled)
farmhash-hash-switch-string x 513,406 ops/sec ±0.53% (98 runs sampled)
farmhash-hash-switch-buffer x 779,636 ops/sec ±0.45% (100 runs sampled)
farmhash-hash-buffer-only x 1,085,798 ops/sec ±0.56% (99 runs sampled)
farmhash-hash-string-only x 502,066 ops/sec ±0.53% (99 runs sampled)
farmhash-hash+seed-switch-string x 510,084 ops/sec ±0.51% (98 runs sampled)
farmhash-hash+seed-switch-buffer x 798,303 ops/sec ±0.43% (93 runs sampled)
farmhash-hash+seed-string-only x 506,372 ops/sec ±0.49% (96 runs sampled)
farmhash-hash+seed-buffer-only x 1,055,082 ops/sec ±0.38% (102 runs sampled)
farmhash-fingerprint x 282,423 ops/sec ±0.54% (96 runs sampled)
xxhash+seed x 618,507 ops/sec ±0.41% (100 runs sampled)
```
### EC2 m3.xlarge us-west-2

```
Test key length performance
Using seed 1993162035
Using key of length 100
murmurhash3 x 2,042,621 ops/sec ±0.40% (98 runs sampled)
murmurhash3+seed x 1,985,653 ops/sec ±0.12% (100 runs sampled)
farmhash-hash-switch-string x 2,788,833 ops/sec ±0.25% (100 runs sampled)
farmhash-hash-switch-buffer x 2,530,404 ops/sec ±0.15% (103 runs sampled)
farmhash-hash-buffer-only x 6,705,966 ops/sec ±0.83% (99 runs sampled)
farmhash-hash-string-only x 2,811,600 ops/sec ±0.04% (100 runs sampled)
farmhash-hash+seed-switch-string x 2,314,911 ops/sec ±0.12% (97 runs sampled)
farmhash-hash+seed-switch-buffer x 2,479,593 ops/sec ±0.11% (100 runs sampled)
farmhash-hash+seed-string-only x 2,711,889 ops/sec ±0.08% (97 runs sampled)
farmhash-hash+seed-buffer-only x 6,332,624 ops/sec ±0.09% (100 runs sampled)
farmhash-fingerprint x 2,765,768 ops/sec ±0.03% (103 runs sampled)
xxhash+seed x 3,594,688 ops/sec ±2.33% (92 runs sampled)
Using key of length 1000
murmurhash3 x 973,754 ops/sec ±0.58% (98 runs sampled)
murmurhash3+seed x 1,277,748 ops/sec ±1.85% (101 runs sampled)
farmhash-hash-switch-string x 1,703,791 ops/sec ±0.09% (97 runs sampled)
farmhash-hash-switch-buffer x 1,869,872 ops/sec ±0.21% (92 runs sampled)
farmhash-hash-buffer-only x 4,814,756 ops/sec ±0.24% (96 runs sampled)
farmhash-hash-string-only x 1,609,365 ops/sec ±0.09% (103 runs sampled)
farmhash-hash+seed-switch-string x 1,571,194 ops/sec ±0.06% (102 runs sampled)
farmhash-hash+seed-switch-buffer x 1,888,304 ops/sec ±0.09% (103 runs sampled)
farmhash-hash+seed-string-only x 1,649,504 ops/sec ±0.12% (102 runs sampled)
farmhash-hash+seed-buffer-only x 4,171,059 ops/sec ±0.09% (102 runs sampled)
farmhash-fingerprint x 1,050,965 ops/sec ±0.30% (101 runs sampled)
xxhash+seed x 2,028,424 ops/sec ±0.07% (104 runs sampled)
Using key of length 10000
murmurhash3 x 200,382 ops/sec ±0.62% (96 runs sampled)
murmurhash3+seed x 201,576 ops/sec ±0.06% (103 runs sampled)
farmhash-hash-switch-string x 405,098 ops/sec ±0.77% (95 runs sampled)
farmhash-hash-switch-buffer x 703,479 ops/sec ±0.06% (101 runs sampled)
farmhash-hash-buffer-only x 1,233,079 ops/sec ±0.11% (100 runs sampled)
farmhash-hash-string-only x 395,867 ops/sec ±0.04% (100 runs sampled)
farmhash-hash+seed-switch-string x 397,470 ops/sec ±0.05% (101 runs sampled)
farmhash-hash+seed-switch-buffer x 711,409 ops/sec ±0.08% (103 runs sampled)
farmhash-hash+seed-string-only x 394,845 ops/sec ±0.05% (98 runs sampled)
farmhash-hash+seed-buffer-only x 1,169,189 ops/sec ±0.04% (103 runs sampled)
farmhash-fingerprint x 224,409 ops/sec ±0.20% (97 runs sampled)
xxhash+seed x 484,341 ops/sec ±1.03% (101 runs sampled)
```
