### PR TITLE
Configurable -march=native cflag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ node_js:
 os:
   - linux
   - osx
+env:
+  - FARMHASH_NOMARCH=y
+  - FARMHASH_NOMARCH=
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ on Linux, OS X and Windows.
 npm install farmhash
 ```
 
+Flag `-march=native` is passed to C compiler by default, which can be
+problematic if CPU of the build host is not the same as CPU of where the code
+is executed (will cause `115 Illegal instruction` during startup).
+
+To avoid `-march=native` cflag, you will need to export an environment variable:
+
+    env FARMHASH_NOMARCH=y npm install farmhash
+
+Note that disabling compiler optimizations will cause performance impact.
+Measure first.
+
 ## Usage
 
 ```javascript

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,4 @@
 {
-  'variables' : {
-    'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
-    },
   'targets': [{
     'target_name': 'farmhash',
     'sources': [
@@ -24,6 +21,10 @@
         'defines': [
           'FARMHASH_OPTIONAL_BUILTIN_EXPECT'
         ]
+      }, {
+        'variables' : {
+          'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
+        },
       }]
     ],
     'xcode_settings': {
@@ -69,6 +70,10 @@
         'defines': [
           'FARMHASH_OPTIONAL_BUILTIN_EXPECT'
         ]
+      }, {
+        'variables' : {
+          'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
+        },
       }]
     ],
     'xcode_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables' : {
+    'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
+    },
   'targets': [{
     'target_name': 'farmhash',
     'sources': [
@@ -11,10 +14,10 @@
     'cflags_cc': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
         '-Ofast',
         '-flto',
-        '-funroll-loops'
+        '-funroll-loops',
+        '<@(march)',
     ],
     'conditions': [
       [ 'OS=="win"', {
@@ -27,9 +30,9 @@
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
         '-Ofast',
-        '-funroll-loops'
+        '-funroll-loops',
+        '<@(march)',
       ]
     },
     'configurations': {
@@ -56,10 +59,10 @@
     'cflags_cc': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
         '-Ofast',
         '-flto',
-        '-funroll-loops'
+        '-funroll-loops',
+        '<@(march)',
     ],
     'conditions': [
       [ 'OS=="win"', {
@@ -72,9 +75,9 @@
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
         '-Ofast',
-        '-funroll-loops'
+        '-funroll-loops',
+        '<@(march)',
       ]
     },
     'configurations': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,9 +21,9 @@
         'defines': [
           'FARMHASH_OPTIONAL_BUILTIN_EXPECT'
         ]
-      }, {
+      }, {  # OS != "win"
         'variables' : {
-          'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
+          'march': '<!(test -z "${FARMHASH_NOMARCH:-}" && echo -march=native || :)'
         },
       }]
     ],
@@ -70,9 +70,9 @@
         'defines': [
           'FARMHASH_OPTIONAL_BUILTIN_EXPECT'
         ]
-      }, {
+      }, {  # OS != "win"
         'variables' : {
-          'march': '<!(node -e "console.log(process.env.FARMHASH_NOMARCH?\\"\\":\\"-march=native\\")")',
+          'march': '<!(test -z "${FARMHASH_NOMARCH:-}" && echo -march=native || :)'
         },
       }]
     ],


### PR DESCRIPTION
The build host might use a different CPU than the compute host. In that
case, we want to omit '-march=native' cflag.

If FARMHASH_NOMARCH is non-empty during the build time, the flag will
be omitted.

For discussion: not sure if we want `FARMHASH_NOMARCH` in `.travis.yml`. I included it in a separate commit, but am not sure if you want to extend the build matrix with it.