### PR TITLE
Allow different `-march` flag for cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ on Linux, OS X and Windows.
 npm install farmhash
 ```
 
+Flag `-march=native` is passed to C compiler by default, which can be
+problematic if CPU of the build host is not the same as CPU of where the code
+is executed (will cause `115 Illegal instruction` during startup).
+
+You can specify another machine architecture during `npm install` phase:
+
+    npm install farmhash --farmhash-arch=core2
+
+Note that disabling compiler optimizations will cause performance impact.
+Measure first.
+
 ## Usage
 
 ```javascript

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ environment:
     nodejs_arch: "x64"
 install:
   - ps: Install-Product node $env:nodejs_version $env:nodejs_arch
+  - npm install -g npm
   - npm install
 test_script:
   - npm test

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'farmhash_arch%': 'native'
+  },
   'targets': [{
     'target_name': 'farmhash',
     'sources': [
@@ -11,7 +14,7 @@
     'cflags_cc': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
+        '-march=<(farmhash_arch)',
         '-Ofast',
         '-flto',
         '-funroll-loops'
@@ -27,7 +30,7 @@
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
+        '-march=<(farmhash_arch)',
         '-Ofast',
         '-funroll-loops'
       ]
@@ -56,7 +59,7 @@
     'cflags_cc': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
+        '-march=<(farmhash_arch)',
         '-Ofast',
         '-flto',
         '-funroll-loops'
@@ -72,7 +75,7 @@
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
+        '-march=<(farmhash_arch)',
         '-Ofast',
         '-funroll-loops'
       ]


### PR DESCRIPTION
Flag `-march=native` is passed to C compiler by default, which can be problematic if CPU of the build host is not the same as CPU of where the code is executed (will cause `115 Illegal instruction` during startup).

You can specify another machine architecture during `npm install` phase:

    npm install farmhash --farmhash-arch=core2

Note that disabling compiler optimizations will cause performance impact. Measure first.