### PR TITLE
Add .node suffix for requiring module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const farmhash = require('./build/Release/farmhash');
+const farmhash = require('./build/Release/farmhash.node');
 
 // Input validation
 function verifyInteger (input) {


### PR DESCRIPTION
Sorry, I can't require the module without the suffix. I have no idea that it's a bug or the problem caused by the environment.