### PR TITLE
binding: add support for AppleSilicon chips

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,13 @@
         'cflags_cc': [
           '-march=native'
         ]
+      }],
+      ['target_arch!="arm64"', {
+        'xcode_settings': {
+          'OTHER_CPLUSPLUSFLAGS+': [
+            '-march=native',
+          ]
+        }
       }]
     ],
     'xcode_settings': {
@@ -43,7 +50,6 @@
       'OTHER_CPLUSPLUSFLAGS': [
         '-fexceptions',
         '-Wall',
-        '-march=native',
         '-Ofast',
         '-funroll-loops'
       ]


### PR DESCRIPTION
This adds support for building on AppleSilicon.
clang does not support `-march=native` on AppleSilicon
at this time.