### PR TITLE
support debug builds of farmhash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const farmhash = require('./build/Release/farmhash.node');
+const farmhash = (function farmhashBinding () {
+  try {
+    return require('./build/Release/farmhash.node');
+  } catch (e) {
+    return require('./build/Debug/farmhash.node');
+  }
+}());
 
 // Input validation
 function verifyInteger (input) {


### PR DESCRIPTION
When running on a debug build of node, a debug build of farmhash is created, and this currently fails due to being hard coded against the release build.