### PR TITLE
Handle spaces in parent directory name

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
        'src/bindings.cc'
     ],
     'include_dirs' : [
-      "<!@(node -p \"require('node-addon-api').include\")"
+      "<!@(node -p \"require('node-addon-api').include_dir\")"
     ],
     'dependencies': [
       "<!(node -p \"require('node-addon-api').gyp\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
        'src/bindings.cc'
     ],
     'include_dirs' : [
-      "<!@(node -p \"require('node-addon-api').include_dir\")"
+      "<!(node -p \"require('node-addon-api').include_dir\")"
     ],
     'dependencies': [
       "<!(node -p \"require('node-addon-api').gyp\")"


### PR DESCRIPTION
If there is a space in the parent directory name farmhash will not compile.  If fails with:

> CXX(target) Release/obj.target/farmhash/src/upstream/farmhash.o
> clang: error: no such file or directory: 'space/node_modules/node-addon-api'
> make: *** [Release/obj.target/farmhash/src/upstream/farmhash.o] Error 1
> gyp ERR! build error 
> gyp ERR! stack Error: `make` failed with exit code: 2
> gyp ERR! stack     at ChildProcess.onExit (ROOT/src/framfash-with space/node_modules/node-gyp/lib/build.js:194:23)
> gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
> gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)
> gyp ERR! System Darwin 21.5.0
> gyp ERR! command "ROOT/.nvm/versions/node/v16.18.0/bin/node" "ROOT/src/framfash-with space/node_modules/.bin/node-gyp" "rebuild"
> gyp ERR! cwd ROOT/src/framfash-with space
> gyp ERR! node -v v16.18.0
> gyp ERR! node-gyp -v v6.1.0

The generated build/farmhash.target.mk does not quote the include path.

This change uses a relative path which is handled correctly.