### PR TITLE
add node-gyp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   ],
   "dependencies": {
     "node-addon-api": "^5.1.0",
-    "prebuild-install": "^7.1.2"
+    "prebuild-install": "^7.1.2",
+    "node-gyp": "^10.1.0"
   },
   "devDependencies": {
     "cc": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   ],
   "dependencies": {
     "node-addon-api": "^5.1.0",
-    "prebuild-install": "^7.1.2",
-    "node-gyp": "^10.1.0"
+    "node-gyp": "^10.1.0",
+    "prebuild-install": "^7.1.2"
   },
   "devDependencies": {
     "cc": "^3.0.1",


### PR DESCRIPTION
`yarn install` in my project failed without globally installed node-gyp, so I added it to the dependencies
```
$ yarn install
...
warning Error running install script for optional dependency: "<path-to-repo>/node_modules/watchpack-chokidar2/node_modules/fsevents: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: <path-to-repo>/node_modules/watchpack-chokidar2/node_modules/fsevents
Output:
node:events:495
      throw er; // Unhandled 'error' event
      ^

Error: spawn node-gyp ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:284:19)
    at onErrorNT (node:internal/child_process:477:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:290:12)
    at onErrorNT (node:internal/child_process:477:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn node-gyp',
  path: 'node-gyp',
  spawnargs: [ 'rebuild' ]
[11/18] ⠈ farmhash
[15/18] ⠈ core-js
[17/18] ⠈ @swc/core
[14/18] ⠈ ngrok
error <path-to-repo>/node_modules/farmhash: Command failed.
Exit code: 127
Command: prebuild-install || node-gyp rebuild
Arguments: 
Directory: <path-to-repo>/node_modules/farmhash
```
```
$ yarn why farmhash
...
=> Found "farmhash@3.3.0"
info Reasons this module exists
   - "firebase-admin" depends on it
   - Hoisted from "firebase-admin#farmhash"
info Disk size without dependencies: "356KB"
info Disk size with unique dependencies: "860KB"
info Disk size with transitive dependencies: "3.66MB"
info Number of shared dependencies: 26
✨  Done in 0.45s.
```