### PR TITLE
Disable debug mode in hash functions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,6 +25,9 @@
         ]
       }]
     ],
+    'defines': [
+      'FARMHASH_DEBUG=0'
+    ],
     'xcode_settings': {
       'CLANG_CXX_LIBRARY': 'libc++',
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',


### PR DESCRIPTION
a last step of the hash functions runs one more swap if activated debug mode.

this debug flags  makes slow down the processing speed and it also always makes different result as fingerprint.

close #51