### PR TITLE
Change correct return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 export function fingerprint32(input: string | Buffer): number;
 
-export function fingerprint64(input: string | Buffer): BigInt;
+export function fingerprint64(input: string | Buffer): bigint;
 
-export function fingerprint64signed(input: string | Buffer): BigInt;
+export function fingerprint64signed(input: string | Buffer): bigint;
 
 export function hash32(input: string | Buffer): number;
 
 export function hash32WithSeed(input: string | Buffer, seed: number): number;
 
-export function hash64(input: string | Buffer): BigInt;
+export function hash64(input: string | Buffer): bigint;
 
-export function hash64WithSeed(input: string | Buffer, seed: number): BigInt;
+export function hash64WithSeed(input: string | Buffer, seed: number): bigint;
 
-export function hash64WithSeeds(input: string | Buffer, seed1: number, seed2: number): BigInt;
+export function hash64WithSeeds(input: string | Buffer, seed1: number, seed2: number): bigint;


### PR DESCRIPTION
BigInt is not a valid type. it has to be `bigint`

```
error TS2345: Argument of type 'BigInt' is not assignable to parameter of type 'bigint'.
```