### PR TITLE
Feat: Allow individual import of fingerprint64signed

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,12 @@ module.exports = {
     throw new Error('Expected a String or Buffer for input');
   },
   fingerprint64signed: function (input) {
-    return BigInt.asIntN(64, this.fingerprint64(input));
+    if (typeof input === 'string') {
+      return BigInt.asIntN(64, farmhash.Fingerprint64String(input));
+    }
+    if (Buffer.isBuffer(input)) {
+      return BigInt.asIntN(64, farmhash.Fingerprint64Buffer(input));
+    }
+    throw new Error('Expected a String or Buffer for input');
   }
 };


### PR DESCRIPTION
We used to have custom code like this:

``` js
import { fingerprint64 } from "farmhash"

const fingerprint64Signed = (input) => BigInt.asIntN(64, BigInt(fingerprint64(input)))

// later
fingerprint64Signed(someInput)
```

With 4.0 having added `fingerprint64Signed`, I tried to change it accordingly:

``` js
import { fingerprint64signed } from "farmhash"

// later
fingerprint64signed(someInput)
```

Which gave me this error: `TypeError: Cannot read properties of undefined (reading 'fingerprint64')`.

After adjusting the import to `import * as farmhash from "farmhash"` and the code to `farmhash.fingerprint64signed(someInput)`, everything worked as it should, but I'd argue it's counter-intuitive that `fingerprint64signed` is the only method that can only be invoked when using the `import *` syntax (or `require`, of course).

This PR adjusts the method accordingly so it can be imported individually and doesn't rely on a specific import syntax.

I went the path of least resistance and simply re-used the code from `fingerprint64` – while it does repeat, I'd argue it's not a large problem and it is IMO the simplest way to get everything running as expected. Happy to change it, though.